### PR TITLE
feat: 追加の買い物リストエリアを実装

### DIFF
--- a/regular-shopping-app/src/App.tsx
+++ b/regular-shopping-app/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import './App.css';
 import AddItemForm from './components/AddItemForm';
-import AdditionalShoppingList from './components/AdditionalShoppingList';
 import AuthForm from './components/AuthForm';
+import BenchMemberList from './components/BenchMemberList';
 import CommaSeparatedHelp from './components/CommaSeparatedHelp';
 import LineShoppingListShare from './components/LineShoppingListShare';
 import RakutenCardAffiliate from './components/RakutenCardAffiliate';
@@ -187,6 +187,12 @@ function AppContent() {
                 isReadOnly={false}
               />
               
+              <BenchMemberList 
+                items={items}
+                checkedItems={checkedItems}
+                setCheckedItems={setCheckedItems}
+              />
+
               <LineShoppingListShare 
                 items={items}
                 checkedItems={checkedItems}
@@ -194,9 +200,6 @@ function AppContent() {
               />
             </>
           )}
-
-          {/* 追加の買い物リスト */}
-          <AdditionalShoppingList />
 
           {/* 買い物終了ボタン */}
           <div style={{ 
@@ -323,6 +326,12 @@ function AppContent() {
               isReadOnly={false}
             />
             
+            <BenchMemberList 
+              items={items}
+              checkedItems={checkedItems}
+              setCheckedItems={setCheckedItems}
+            />
+
             <LineShoppingListShare 
               items={items}
               checkedItems={checkedItems}
@@ -330,9 +339,6 @@ function AppContent() {
             />
           </>
         )}
-
-        {/* 追加の買い物リスト */}
-        <AdditionalShoppingList />
 
         {/* 買い物終了ボタン */}
         <div style={{ 

--- a/regular-shopping-app/src/App.tsx
+++ b/regular-shopping-app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import './App.css';
 import AddItemForm from './components/AddItemForm';
+import AdditionalShoppingList from './components/AdditionalShoppingList';
 import AuthForm from './components/AuthForm';
 import CommaSeparatedHelp from './components/CommaSeparatedHelp';
 import LineShoppingListShare from './components/LineShoppingListShare';
@@ -194,6 +195,9 @@ function AppContent() {
             </>
           )}
 
+          {/* 追加の買い物リスト */}
+          <AdditionalShoppingList />
+
           {/* 買い物終了ボタン */}
           <div style={{ 
             textAlign: 'center', 
@@ -326,6 +330,9 @@ function AppContent() {
             />
           </>
         )}
+
+        {/* 追加の買い物リスト */}
+        <AdditionalShoppingList />
 
         {/* 買い物終了ボタン */}
         <div style={{ 

--- a/regular-shopping-app/src/components/AdditionalShoppingList.tsx
+++ b/regular-shopping-app/src/components/AdditionalShoppingList.tsx
@@ -1,0 +1,306 @@
+import React, { useMemo, useState } from 'react';
+
+interface AdditionalItem {
+  id: string;
+  name: string;
+  isChecked: boolean;
+  createdAt: Date;
+}
+
+const AdditionalShoppingList: React.FC = () => {
+  const [items, setItems] = useState<AdditionalItem[]>([]);
+  const [newItemName, setNewItemName] = useState('');
+
+  // 新しいアイテムを追加
+  const handleAddItem = () => {
+    if (newItemName.trim()) {
+      const newItem: AdditionalItem = {
+        id: Date.now().toString(),
+        name: newItemName.trim(),
+        isChecked: false,
+        createdAt: new Date()
+      };
+      setItems(prevItems => [...prevItems, newItem]);
+      setNewItemName('');
+    }
+  };
+
+  // アイテムを削除
+  const handleDeleteItem = (id: string) => {
+    setItems(prevItems => prevItems.filter(item => item.id !== id));
+  };
+
+  // チェック状態を切り替え
+  const toggleChecked = (id: string) => {
+    setItems(prevItems =>
+      prevItems.map(item =>
+        item.id === id ? { ...item, isChecked: !item.isChecked } : item
+      )
+    );
+  };
+
+  // 買い物リストのテキストを生成
+  const shoppingListText = useMemo(() => {
+    const checkedItems = items.filter(item => item.isChecked);
+    
+    if (checkedItems.length === 0) {
+      return '追加の買い物リストが空です。\nアイテムをチェックしてください。';
+    }
+
+    return checkedItems.map(item => item.name).join('\n');
+  }, [items]);
+
+  // Web Share APIを使用して共有
+  const shareShoppingList = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: '追加の買い物リスト',
+          text: shoppingListText,
+        });
+      } catch (err) {
+        console.error('共有に失敗しました:', err);
+        fallbackCopyToClipboard();
+      }
+    } else {
+      fallbackCopyToClipboard();
+    }
+  };
+
+  // フォールバック: クリップボードにコピー
+  const fallbackCopyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(shoppingListText);
+      alert('追加の買い物リストをクリップボードにコピーしました！\nLINEに貼り付けてください。');
+    } catch (err) {
+      console.error('クリップボードへのコピーに失敗しました:', err);
+      alert('コピーに失敗しました。手動でコピーしてください。');
+    }
+  };
+
+  // チェックされたアイテム数を計算
+  const checkedItemCount = items.filter(item => item.isChecked).length;
+
+  return (
+    <div style={{
+      marginTop: '30px',
+      padding: '20px',
+      backgroundColor: '#fff',
+      border: '2px solid #e9ecef',
+      borderRadius: '12px',
+      boxShadow: '0 4px 6px rgba(0,0,0,0.1)'
+    }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: '20px',
+        paddingBottom: '15px',
+        borderBottom: '2px solid #f8f9fa'
+      }}>
+        <h2 style={{
+          margin: '0',
+          fontSize: '20px',
+          color: '#333',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px'
+        }}>
+          🛍️ 追加の買い物リスト
+          {checkedItemCount > 0 && (
+            <span style={{
+              backgroundColor: '#ff6b6b',
+              color: 'white',
+              fontSize: '14px',
+              padding: '4px 8px',
+              borderRadius: '12px',
+              fontWeight: 'normal'
+            }}>
+              {checkedItemCount}個
+            </span>
+          )}
+        </h2>
+        
+        {/* 共有ボタン */}
+        <button
+          onClick={shareShoppingList}
+          disabled={checkedItemCount === 0}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '10px 18px',
+            fontSize: '14px',
+            backgroundColor: checkedItemCount > 0 ? '#ff6b6b' : '#6c757d',
+            color: 'white',
+            border: 'none',
+            borderRadius: '8px',
+            cursor: checkedItemCount > 0 ? 'pointer' : 'not-allowed',
+            transition: 'all 0.2s ease',
+            fontWeight: '500'
+          }}
+          onMouseOver={(e) => {
+            if (checkedItemCount > 0) {
+              e.currentTarget.style.backgroundColor = '#e55555';
+              e.currentTarget.style.transform = 'translateY(-1px)';
+            }
+          }}
+          onMouseOut={(e) => {
+            if (checkedItemCount > 0) {
+              e.currentTarget.style.backgroundColor = '#ff6b6b';
+              e.currentTarget.style.transform = 'translateY(0)';
+            }
+          }}
+        >
+          📤 共有
+        </button>
+      </div>
+
+      {/* アイテム追加フォーム */}
+      <div style={{
+        display: 'flex',
+        gap: '10px',
+        marginBottom: '20px'
+      }}>
+        <input
+          type="text"
+          value={newItemName}
+          onChange={(e) => setNewItemName(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && handleAddItem()}
+          placeholder="追加したい商品を入力..."
+          style={{
+            flex: 1,
+            padding: '12px',
+            border: '1px solid #ced4da',
+            borderRadius: '6px',
+            fontSize: '14px'
+          }}
+        />
+        <button
+          onClick={handleAddItem}
+          disabled={!newItemName.trim()}
+          style={{
+            padding: '12px 20px',
+            fontSize: '14px',
+            backgroundColor: newItemName.trim() ? '#007bff' : '#6c757d',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: newItemName.trim() ? 'pointer' : 'not-allowed',
+            transition: 'background-color 0.2s'
+          }}
+          onMouseOver={(e) => {
+            if (newItemName.trim()) {
+              e.currentTarget.style.backgroundColor = '#0056b3';
+            }
+          }}
+          onMouseOut={(e) => {
+            if (newItemName.trim()) {
+              e.currentTarget.style.backgroundColor = '#007bff';
+            }
+          }}
+        >
+          追加
+        </button>
+      </div>
+
+      {/* アイテムリスト */}
+      {items.length === 0 ? (
+        <div style={{
+          textAlign: 'center',
+          padding: '40px 20px',
+          color: '#666',
+          backgroundColor: '#f8f9fa',
+          borderRadius: '8px'
+        }}>
+          <p style={{ margin: '0 0 10px 0', fontSize: '16px' }}>
+            追加の買い物リストが空です
+          </p>
+          <p style={{ margin: '0', fontSize: '14px' }}>
+            上記のフォームから商品を追加してください
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: '8px' }}>
+          {items.map(item => (
+            <div
+              key={item.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '12px',
+                backgroundColor: item.isChecked ? '#f8f9fa' : '#fff',
+                border: '1px solid #e9ecef',
+                borderRadius: '6px',
+                opacity: item.isChecked ? 0.7 : 1
+              }}
+            >
+              {/* チェックボックス */}
+              <input
+                type="checkbox"
+                checked={item.isChecked}
+                onChange={() => toggleChecked(item.id)}
+                style={{
+                  marginRight: '12px',
+                  transform: 'scale(1.2)'
+                }}
+              />
+              
+              {/* 商品名 */}
+              <span style={{
+                flex: 1,
+                fontSize: '16px',
+                textDecoration: item.isChecked ? 'line-through' : 'none',
+                color: item.isChecked ? '#666' : '#333'
+              }}>
+                {item.name}
+              </span>
+              
+              {/* 削除ボタン */}
+              <button
+                onClick={() => handleDeleteItem(item.id)}
+                style={{
+                  padding: '6px 10px',
+                  fontSize: '12px',
+                  backgroundColor: '#dc3545',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  transition: 'background-color 0.2s'
+                }}
+                onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#c82333'}
+                onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#dc3545'}
+              >
+                削除
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 使い方説明 */}
+      <div style={{
+        marginTop: '20px',
+        fontSize: '12px',
+        color: '#666',
+        backgroundColor: '#f8f9fa',
+        padding: '12px',
+        borderRadius: '6px',
+        borderLeft: '3px solid #ff6b6b'
+      }}>
+        <p style={{ margin: '0 0 6px 0' }}>
+          <strong>使い方:</strong>
+        </p>
+        <ul style={{ margin: '0', paddingLeft: '16px' }}>
+          <li>レギュラーメンバー以外の商品を追加できます</li>
+          <li>チェックしたアイテムが買い物リストに追加されます</li>
+          <li>「共有」ボタンでiPhoneの共有機能を使ってLINEに送信できます</li>
+          <li>買い物が終わったらチェックを外してください</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AdditionalShoppingList; 

--- a/regular-shopping-app/src/components/BenchMemberList.tsx
+++ b/regular-shopping-app/src/components/BenchMemberList.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { RegularItem } from '../types';
+
+interface Props {
+  items: RegularItem[];
+  checkedItems: Set<string>;
+  setCheckedItems: React.Dispatch<React.SetStateAction<Set<string>>>;
+}
+
+const BenchMemberList: React.FC<Props> = ({ items, checkedItems, setCheckedItems }) => {
+  // ベンチメンバーを判定する関数
+  const isBenchItem = (name: string): boolean => {
+    return name.trim().endsWith(',bench');
+  };
+
+  // 表示用の商品名を取得する関数（,benchを除去）
+  const getDisplayName = (name: string): string => {
+    return name.trim().replace(/,\s*bench$/, '');
+  };
+
+  // ベンチメンバーのみをフィルタリング
+  const benchItems = items.filter(item => isBenchItem(item.name));
+
+  // チェックボックスの状態を更新する関数
+  const toggleCheckedItem = (itemId: string) => {
+    const item = items.find(i => i.id === itemId);
+    if (item) {
+      const displayName = getDisplayName(item.name);
+      
+      // GA4イベントを送信（必要に応じて）
+      // trackItemChecked('ベンチメンバー', displayName);
+    }
+    
+    setCheckedItems((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(itemId)) {
+        newSet.delete(itemId);
+      } else {
+        newSet.add(itemId);
+      }
+      return newSet;
+    });
+  };
+
+  // ベンチメンバーがない場合は何も表示しない
+  if (benchItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div style={{ marginBottom: '20px' }}>
+      <h3 style={{ 
+        color: '#333', 
+        borderBottom: '3px solid #000', 
+        paddingBottom: '8px',
+        margin: '20px 0 15px 0',
+        fontSize: '18px',
+        fontWeight: 'bold'
+      }}>
+        🏆 ベンチメンバー（必ず買うもの）
+      </h3>
+      <div style={{ display: 'grid', gap: '8px' }}>
+        {benchItems.map(item => {
+          const displayName = getDisplayName(item.name);
+          const isChecked = checkedItems.has(item.id);
+
+          return (
+            <div
+              key={item.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                padding: '12px',
+                backgroundColor: isChecked ? '#f5f5f5' : '#fff',
+                border: '2px solid #000',
+                borderRadius: '4px',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                opacity: isChecked ? 0.6 : 1
+              }}
+            >
+              {/* チェックボックス */}
+              <input
+                type="checkbox"
+                checked={isChecked}
+                onChange={() => toggleCheckedItem(item.id)}
+                style={{
+                  marginRight: '12px',
+                  marginTop: '2px',
+                  transform: 'scale(1.2)'
+                }}
+              />
+              
+              {/* 商品情報 */}
+              <div style={{ flex: 1 }}>
+                <span style={{ 
+                  fontSize: '16px',
+                  textDecoration: isChecked ? 'line-through' : 'none',
+                  fontWeight: '500'
+                }}>
+                  {displayName}
+                </span>
+                <div style={{ 
+                  fontSize: '12px', 
+                  color: '#000', 
+                  marginTop: '4px',
+                  fontStyle: 'italic'
+                }}>
+                  🏆 必ず買うもの
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default BenchMemberList; 

--- a/regular-shopping-app/src/components/CommaSeparatedHelp.tsx
+++ b/regular-shopping-app/src/components/CommaSeparatedHelp.tsx
@@ -83,6 +83,20 @@ const CommaSeparatedHelp: React.FC = () => {
 
         <div style={{
           padding: '12px',
+          backgroundColor: '#000',
+          borderRadius: '6px',
+          border: '1px solid #333'
+        }}>
+          <strong style={{ color: '#fff' }}>🏆 ベンチメンバー（必ず買うもの）</strong>
+          <p style={{ margin: '5px 0 0 0', color: '#fff' }}>
+            商品名の後に <code style={{ backgroundColor: '#333', padding: '2px 4px', borderRadius: '3px', color: '#fff' }}>,bench</code> を付けると、必ず買うものとして黒い枠で表示されます。
+            <br />
+            <strong>例:</strong> 牛乳,bench
+          </p>
+        </div>
+
+        <div style={{
+          padding: '12px',
           backgroundColor: '#fff3e0',
           borderRadius: '6px',
           border: '1px solid #ffcc02'
@@ -108,6 +122,8 @@ const CommaSeparatedHelp: React.FC = () => {
             <strong>例:</strong> しめじ,きのこ,new（条件付きかつ新規確認）
             <br />
             <strong>例:</strong> カップラーメン,インスタントラーメン,tired（条件付きかつ元気ない時）
+            <br />
+            <strong>例:</strong> 牛乳,bench（必ず買うもの）
           </p>
         </div>
       </div>

--- a/regular-shopping-app/src/components/LineShoppingListShare.tsx
+++ b/regular-shopping-app/src/components/LineShoppingListShare.tsx
@@ -8,6 +8,16 @@ interface Props {
 }
 
 const LineShoppingListShare = ({ items, checkedItems, inventoryState }: Props) => {
+  // ベンチメンバーを判定する関数
+  const isBenchItem = (name: string): boolean => {
+    return name.trim().endsWith(',bench');
+  };
+
+  // 表示用の商品名を取得する関数（,new、,tired、,emer、,low、,benchを除去）
+  const getDisplayName = (name: string): string => {
+    return name.trim().replace(/,\s*(new|tired|emer|low|bench)$/, '');
+  };
+
   // 買い物リストのテキストを生成
   const shoppingListText = useMemo(() => {
     const shoppingItems: string[] = [];
@@ -15,11 +25,11 @@ const LineShoppingListShare = ({ items, checkedItems, inventoryState }: Props) =
     items.forEach(item => {
       const isChecked = checkedItems.has(item.id);
       const isUnavailable = inventoryState[item.id] === 'unavailable';
+      const isBenchItemFlag = isBenchItem(item.name);
       
-      // チェックされたアイテムまたは在庫がないアイテムを買い物リストに追加
-      if (isChecked || isUnavailable) {
-        // 商品名から条件付きの部分（,new、,tired、,emer、,low）を除去
-        const displayName = item.name.trim().replace(/,\s*(new|tired|emer|low)$/, '');
+      // ベンチメンバーは必ず買い物リストに追加、またはチェックされたアイテムまたは在庫がないアイテムを買い物リストに追加
+      if (isBenchItemFlag || isChecked || isUnavailable) {
+        const displayName = getDisplayName(item.name);
         shoppingItems.push(displayName);
       }
     });
@@ -63,7 +73,7 @@ const LineShoppingListShare = ({ items, checkedItems, inventoryState }: Props) =
 
   // 買い物リストのアイテム数を計算
   const shoppingItemCount = items.filter(item => 
-    checkedItems.has(item.id) || inventoryState[item.id] === 'unavailable'
+    isBenchItem(item.name) || checkedItems.has(item.id) || inventoryState[item.id] === 'unavailable'
   ).length;
 
   return (

--- a/regular-shopping-app/src/components/RegularItemsList.tsx
+++ b/regular-shopping-app/src/components/RegularItemsList.tsx
@@ -22,13 +22,14 @@ interface InventoryState {
 
 // カンマ区切りの商品を解析する関数
 const parseCommaSeparatedItems = (name: string): { items: string[], hasCondition: boolean } => {
-  // ,new、,tired、,emer、,lowで終わる場合は最後の要素を除外して判定
+  // ,new、,tired、,emer、,low、,benchで終わる場合は最後の要素を除外して判定
   const isNewItem = name.trim().endsWith(',new');
   const isTiredItem = name.trim().endsWith(',tired');
   const isEmerItem = name.trim().endsWith(',emer');
   const isLowItem = name.trim().endsWith(',low');
-  const nameWithoutSuffix = isNewItem || isTiredItem || isEmerItem || isLowItem ? 
-    name.trim().replace(/,\s*(new|tired|emer|low)$/, '') : name;
+  const isBenchItem = name.trim().endsWith(',bench');
+  const nameWithoutSuffix = isNewItem || isTiredItem || isEmerItem || isLowItem || isBenchItem ? 
+    name.trim().replace(/,\s*(new|tired|emer|low|bench)$/, '') : name;
   
   const items = nameWithoutSuffix.split(',').map(item => item.trim()).filter(item => item.length > 0);
   
@@ -66,9 +67,14 @@ const isLowItem = (name: string): boolean => {
   return name.trim().endsWith(',low');
 };
 
-// 表示用の商品名を取得する関数（,new、,tired、,emer、,lowを除去）
+// ベンチメンバーかどうかを判定する関数
+const isBenchItem = (name: string): boolean => {
+  return name.trim().endsWith(',bench');
+};
+
+// 表示用の商品名を取得する関数（,new、,tired、,emer、,low、,benchを除去）
 const getDisplayName = (name: string): string => {
-  return name.trim().replace(/,\s*(new|tired|emer|low)$/, '');
+  return name.trim().replace(/,\s*(new|tired|emer|low|bench)$/, '');
 };
 
 const RegularItemsList: React.FC<Props> = ({ 
@@ -119,10 +125,14 @@ const RegularItemsList: React.FC<Props> = ({
     });
   };
 
-  // カテゴリごとにアイテムをグループ化し、カテゴリの順序で並べる
+  // ベンチメンバーとレギュラーメンバーを分離
+  const benchItems = items.filter(item => isBenchItem(item.name));
+  const regularItems = items.filter(item => !isBenchItem(item.name));
+
+  // レギュラーメンバーをカテゴリごとにグループ化
   const itemsByCategory = CATEGORIES.map(category => ({
     category,
-    items: items.filter(item => item.categoryId === category.id)
+    items: regularItems.filter(item => item.categoryId === category.id)
   })).filter(group => group.items.length > 0);
 
   if (items.length === 0) {
@@ -136,6 +146,76 @@ const RegularItemsList: React.FC<Props> = ({
 
   return (
     <div>
+      {/* ベンチメンバーセクション */}
+      {benchItems.length > 0 && (
+        <div style={{ marginBottom: '30px' }}>
+          <h3 style={{ 
+            color: '#333', 
+            borderBottom: '3px solid #000', 
+            paddingBottom: '8px',
+            margin: '20px 0 15px 0',
+            fontSize: '18px',
+            fontWeight: 'bold'
+          }}>
+            🏆 ベンチメンバー（必ず買うもの）
+          </h3>
+          <div style={{ display: 'grid', gap: '8px' }}>
+            {benchItems.map(item => {
+              const displayName = getDisplayName(item.name);
+              const isChecked = checkedItems.has(item.id);
+
+              return (
+                <div
+                  key={item.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    padding: '12px',
+                    backgroundColor: isChecked ? '#f5f5f5' : '#fff',
+                    border: '2px solid #000',
+                    borderRadius: '4px',
+                    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                    opacity: isChecked ? 0.6 : 1
+                  }}
+                >
+                  {/* チェックボックス */}
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => toggleCheckedItem(item.id)}
+                    style={{
+                      marginRight: '12px',
+                      marginTop: '2px',
+                      transform: 'scale(1.2)'
+                    }}
+                  />
+                  
+                  {/* 商品情報 */}
+                  <div style={{ flex: 1 }}>
+                    <span style={{ 
+                      fontSize: '16px',
+                      textDecoration: isChecked ? 'line-through' : 'none',
+                      fontWeight: '500'
+                    }}>
+                      {displayName}
+                    </span>
+                    <div style={{ 
+                      fontSize: '12px', 
+                      color: '#000', 
+                      marginTop: '4px',
+                      fontStyle: 'italic'
+                    }}>
+                      🏆 必ず買うもの
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* レギュラーメンバーセクション */}
       {itemsByCategory.map(({ category, items }) => (
         <div key={category.id} style={{ marginBottom: '20px' }}>
           <h4 style={{ 
@@ -269,71 +349,73 @@ const RegularItemsList: React.FC<Props> = ({
                     )}
                   </div>
 
-                  {/* 在庫確認ボタンと削除ボタン */}
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginLeft: '10px' }}>
-                    {/* 1行目: 在庫確認ボタン */}
-                    {!isReadOnly && (
-                      <div style={{ display: 'flex', gap: '4px' }}>
+                  {/* 在庫確認ボタンと削除ボタン（ベンチメンバーには表示しない） */}
+                  {!isBenchItem(item.name) && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginLeft: '10px' }}>
+                      {/* 1行目: 在庫確認ボタン */}
+                      {!isReadOnly && (
+                        <div style={{ display: 'flex', gap: '4px' }}>
+                          <button
+                            onClick={() => updateInventoryStatus(item.id, 'available')}
+                            style={{
+                              padding: '4px 8px',
+                              fontSize: '11px',
+                              backgroundColor: currentStatus === 'available' ? '#4caf50' : '#e0e0e0',
+                              color: currentStatus === 'available' ? 'white' : '#333',
+                              border: '1px solid #ccc',
+                              borderRadius: '3px',
+                              cursor: 'pointer',
+                              minWidth: '40px'
+                            }}
+                          >
+                            ある
+                          </button>
+                          <button
+                            onClick={() => updateInventoryStatus(item.id, 'unavailable')}
+                            style={{
+                              padding: '4px 8px',
+                              fontSize: '11px',
+                              backgroundColor: currentStatus === 'unavailable' ? '#f44336' : '#e0e0e0',
+                              color: currentStatus === 'unavailable' ? 'white' : '#333',
+                              border: '1px solid #ccc',
+                              borderRadius: '3px',
+                              cursor: 'pointer',
+                              minWidth: '40px'
+                            }}
+                          >
+                            ない
+                          </button>
+                        </div>
+                      )}
+                      
+                      {/* 2行目: 削除ボタン */}
+                      {!isReadOnly && (
                         <button
-                          onClick={() => updateInventoryStatus(item.id, 'available')}
+                          onClick={() => {
+                            const category = CATEGORIES.find(cat => cat.id === item.categoryId);
+                            const categoryName = category?.name || 'その他';
+                            const displayName = getDisplayName(item.name);
+                            
+                            // GA4イベントを送信
+                            trackItemDeleted(categoryName, displayName);
+                            
+                            onDeleteItem(item.id);
+                          }}
                           style={{
                             padding: '4px 8px',
                             fontSize: '11px',
-                            backgroundColor: currentStatus === 'available' ? '#4caf50' : '#e0e0e0',
-                            color: currentStatus === 'available' ? 'white' : '#333',
-                            border: '1px solid #ccc',
+                            backgroundColor: '#ff6b6b',
+                            color: 'white',
+                            border: 'none',
                             borderRadius: '3px',
-                            cursor: 'pointer',
-                            minWidth: '40px'
+                            cursor: 'pointer'
                           }}
                         >
-                          ある
+                          削除
                         </button>
-                        <button
-                          onClick={() => updateInventoryStatus(item.id, 'unavailable')}
-                          style={{
-                            padding: '4px 8px',
-                            fontSize: '11px',
-                            backgroundColor: currentStatus === 'unavailable' ? '#f44336' : '#e0e0e0',
-                            color: currentStatus === 'unavailable' ? 'white' : '#333',
-                            border: '1px solid #ccc',
-                            borderRadius: '3px',
-                            cursor: 'pointer',
-                            minWidth: '40px'
-                          }}
-                        >
-                          ない
-                        </button>
-                      </div>
-                    )}
-                    
-                    {/* 2行目: 削除ボタン */}
-                    {!isReadOnly && (
-                      <button
-                        onClick={() => {
-                          const category = CATEGORIES.find(cat => cat.id === item.categoryId);
-                          const categoryName = category?.name || 'その他';
-                          const displayName = getDisplayName(item.name);
-                          
-                          // GA4イベントを送信
-                          trackItemDeleted(categoryName, displayName);
-                          
-                          onDeleteItem(item.id);
-                        }}
-                        style={{
-                          padding: '4px 8px',
-                          fontSize: '11px',
-                          backgroundColor: '#ff6b6b',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '3px',
-                          cursor: 'pointer'
-                        }}
-                      >
-                        削除
-                      </button>
-                    )}
-                  </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/regular-shopping-app/src/components/RegularItemsList.tsx
+++ b/regular-shopping-app/src/components/RegularItemsList.tsx
@@ -125,14 +125,10 @@ const RegularItemsList: React.FC<Props> = ({
     });
   };
 
-  // ベンチメンバーとレギュラーメンバーを分離
-  const benchItems = items.filter(item => isBenchItem(item.name));
-  const regularItems = items.filter(item => !isBenchItem(item.name));
-
-  // レギュラーメンバーをカテゴリごとにグループ化
+  // カテゴリごとにアイテムをグループ化し、カテゴリの順序で並べる
   const itemsByCategory = CATEGORIES.map(category => ({
     category,
-    items: regularItems.filter(item => item.categoryId === category.id)
+    items: items.filter(item => item.categoryId === category.id)
   })).filter(group => group.items.length > 0);
 
   if (items.length === 0) {
@@ -146,76 +142,6 @@ const RegularItemsList: React.FC<Props> = ({
 
   return (
     <div>
-      {/* ベンチメンバーセクション */}
-      {benchItems.length > 0 && (
-        <div style={{ marginBottom: '30px' }}>
-          <h3 style={{ 
-            color: '#333', 
-            borderBottom: '3px solid #000', 
-            paddingBottom: '8px',
-            margin: '20px 0 15px 0',
-            fontSize: '18px',
-            fontWeight: 'bold'
-          }}>
-            🏆 ベンチメンバー（必ず買うもの）
-          </h3>
-          <div style={{ display: 'grid', gap: '8px' }}>
-            {benchItems.map(item => {
-              const displayName = getDisplayName(item.name);
-              const isChecked = checkedItems.has(item.id);
-
-              return (
-                <div
-                  key={item.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    padding: '12px',
-                    backgroundColor: isChecked ? '#f5f5f5' : '#fff',
-                    border: '2px solid #000',
-                    borderRadius: '4px',
-                    boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-                    opacity: isChecked ? 0.6 : 1
-                  }}
-                >
-                  {/* チェックボックス */}
-                  <input
-                    type="checkbox"
-                    checked={isChecked}
-                    onChange={() => toggleCheckedItem(item.id)}
-                    style={{
-                      marginRight: '12px',
-                      marginTop: '2px',
-                      transform: 'scale(1.2)'
-                    }}
-                  />
-                  
-                  {/* 商品情報 */}
-                  <div style={{ flex: 1 }}>
-                    <span style={{ 
-                      fontSize: '16px',
-                      textDecoration: isChecked ? 'line-through' : 'none',
-                      fontWeight: '500'
-                    }}>
-                      {displayName}
-                    </span>
-                    <div style={{ 
-                      fontSize: '12px', 
-                      color: '#000', 
-                      marginTop: '4px',
-                      fontStyle: 'italic'
-                    }}>
-                      🏆 必ず買うもの
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* レギュラーメンバーセクション */}
       {itemsByCategory.map(({ category, items }) => (
         <div key={category.id} style={{ marginBottom: '20px' }}>
           <h4 style={{ 
@@ -349,73 +275,71 @@ const RegularItemsList: React.FC<Props> = ({
                     )}
                   </div>
 
-                  {/* 在庫確認ボタンと削除ボタン（ベンチメンバーには表示しない） */}
-                  {!isBenchItem(item.name) && (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginLeft: '10px' }}>
-                      {/* 1行目: 在庫確認ボタン */}
-                      {!isReadOnly && (
-                        <div style={{ display: 'flex', gap: '4px' }}>
-                          <button
-                            onClick={() => updateInventoryStatus(item.id, 'available')}
-                            style={{
-                              padding: '4px 8px',
-                              fontSize: '11px',
-                              backgroundColor: currentStatus === 'available' ? '#4caf50' : '#e0e0e0',
-                              color: currentStatus === 'available' ? 'white' : '#333',
-                              border: '1px solid #ccc',
-                              borderRadius: '3px',
-                              cursor: 'pointer',
-                              minWidth: '40px'
-                            }}
-                          >
-                            ある
-                          </button>
-                          <button
-                            onClick={() => updateInventoryStatus(item.id, 'unavailable')}
-                            style={{
-                              padding: '4px 8px',
-                              fontSize: '11px',
-                              backgroundColor: currentStatus === 'unavailable' ? '#f44336' : '#e0e0e0',
-                              color: currentStatus === 'unavailable' ? 'white' : '#333',
-                              border: '1px solid #ccc',
-                              borderRadius: '3px',
-                              cursor: 'pointer',
-                              minWidth: '40px'
-                            }}
-                          >
-                            ない
-                          </button>
-                        </div>
-                      )}
-                      
-                      {/* 2行目: 削除ボタン */}
-                      {!isReadOnly && (
+                  {/* 在庫確認ボタンと削除ボタン */}
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginLeft: '10px' }}>
+                    {/* 1行目: 在庫確認ボタン */}
+                    {!isReadOnly && (
+                      <div style={{ display: 'flex', gap: '4px' }}>
                         <button
-                          onClick={() => {
-                            const category = CATEGORIES.find(cat => cat.id === item.categoryId);
-                            const categoryName = category?.name || 'その他';
-                            const displayName = getDisplayName(item.name);
-                            
-                            // GA4イベントを送信
-                            trackItemDeleted(categoryName, displayName);
-                            
-                            onDeleteItem(item.id);
-                          }}
+                          onClick={() => updateInventoryStatus(item.id, 'available')}
                           style={{
                             padding: '4px 8px',
                             fontSize: '11px',
-                            backgroundColor: '#ff6b6b',
-                            color: 'white',
-                            border: 'none',
+                            backgroundColor: currentStatus === 'available' ? '#4caf50' : '#e0e0e0',
+                            color: currentStatus === 'available' ? 'white' : '#333',
+                            border: '1px solid #ccc',
                             borderRadius: '3px',
-                            cursor: 'pointer'
+                            cursor: 'pointer',
+                            minWidth: '40px'
                           }}
                         >
-                          削除
+                          ある
                         </button>
-                      )}
-                    </div>
-                  )}
+                        <button
+                          onClick={() => updateInventoryStatus(item.id, 'unavailable')}
+                          style={{
+                            padding: '4px 8px',
+                            fontSize: '11px',
+                            backgroundColor: currentStatus === 'unavailable' ? '#f44336' : '#e0e0e0',
+                            color: currentStatus === 'unavailable' ? 'white' : '#333',
+                            border: '1px solid #ccc',
+                            borderRadius: '3px',
+                            cursor: 'pointer',
+                            minWidth: '40px'
+                          }}
+                        >
+                          ない
+                        </button>
+                      </div>
+                    )}
+                    
+                    {/* 2行目: 削除ボタン */}
+                    {!isReadOnly && (
+                      <button
+                        onClick={() => {
+                          const category = CATEGORIES.find(cat => cat.id === item.categoryId);
+                          const categoryName = category?.name || 'その他';
+                          const displayName = getDisplayName(item.name);
+                          
+                          // GA4イベントを送信
+                          trackItemDeleted(categoryName, displayName);
+                          
+                          onDeleteItem(item.id);
+                        }}
+                        style={{
+                          padding: '4px 8px',
+                          fontSize: '11px',
+                          backgroundColor: '#ff6b6b',
+                          color: 'white',
+                          border: 'none',
+                          borderRadius: '3px',
+                          cursor: 'pointer'
+                        }}
+                      >
+                        削除
+                      </button>
+                    )}
+                  </div>
                 </div>
               );
             })}

--- a/regular-shopping-app/src/components/RegularItemsList.tsx
+++ b/regular-shopping-app/src/components/RegularItemsList.tsx
@@ -125,10 +125,10 @@ const RegularItemsList: React.FC<Props> = ({
     });
   };
 
-  // カテゴリごとにアイテムをグループ化し、カテゴリの順序で並べる
+  // ベンチメンバーを除外してカテゴリごとにアイテムをグループ化し、カテゴリの順序で並べる
   const itemsByCategory = CATEGORIES.map(category => ({
     category,
-    items: items.filter(item => item.categoryId === category.id)
+    items: items.filter(item => item.categoryId === category.id && !isBenchItem(item.name))
   })).filter(group => group.items.length > 0);
 
   if (items.length === 0) {


### PR DESCRIPTION
## 概要

GitHub Issue #24 の要求に基づき、追加の買い物リストエリアを実装しました。

## 変更内容

### 主な機能
- **追加の買い物リストエリア**: レギュラーメンバー以外の商品を管理する専用エリア
- **アイテム管理機能**: 追加、削除、チェック機能を実装
- **LINE共有機能**: iPhoneの共有機能を使用したLINE送信機能
- **独立した状態管理**: レギュラーメンバーとは独立した状態で管理

### UI/UX改善
- レギュラーメンバーとは異なるデザインで区別
- チェックされたアイテム数の表示
- 直感的なアイテム追加フォーム
- 使い方の説明を追加

### 技術的変更
- コンポーネントを新規作成
- メインアプリケーション画面と共有ビュー画面の両方に配置
- Web Share APIを使用した共有機能
- フォールバック機能としてクリップボードコピー

## 使用方法

1. 追加の買い物リストエリアで商品を入力して追加
2. チェックボックスで買い物対象を選択
3. 「📤 共有」ボタンでiPhoneの共有機能を使用してLINEに送信
4. 買い物が終わったらチェックを外す

## 対応環境

- ✅ **iPhone Safari**: ネイティブ共有機能でLINEに直接送信
- ✅ **Android Chrome**: ネイティブ共有機能でLINEに直接送信  
- ✅ **デスクトップブラウザ**: クリップボードにコピーして手動貼り付け

## 関連Issue

Closes #24