### PR TITLE
feat: ベンチメンバーに削除ボタンを追加

### DIFF
--- a/regular-shopping-app/src/App.tsx
+++ b/regular-shopping-app/src/App.tsx
@@ -191,6 +191,8 @@ function AppContent() {
                 items={items}
                 checkedItems={checkedItems}
                 setCheckedItems={setCheckedItems}
+                onDeleteItem={() => {}}
+                isReadOnly={true}
               />
 
               <LineShoppingListShare 
@@ -330,6 +332,8 @@ function AppContent() {
               items={items}
               checkedItems={checkedItems}
               setCheckedItems={setCheckedItems}
+              onDeleteItem={handleDeleteItem}
+              isReadOnly={false}
             />
 
             <LineShoppingListShare 

--- a/regular-shopping-app/src/components/BenchMemberList.tsx
+++ b/regular-shopping-app/src/components/BenchMemberList.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { RegularItem } from '../types';
+import { trackItemDeleted } from '../utils/ga4';
 
 interface Props {
   items: RegularItem[];
   checkedItems: Set<string>;
   setCheckedItems: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onDeleteItem: (id: string) => void;
+  isReadOnly?: boolean;
 }
 
-const BenchMemberList: React.FC<Props> = ({ items, checkedItems, setCheckedItems }) => {
+const BenchMemberList: React.FC<Props> = ({ items, checkedItems, setCheckedItems, onDeleteItem, isReadOnly }) => {
   // ベンチメンバーを判定する関数
   const isBenchItem = (name: string): boolean => {
     return name.trim().endsWith(',bench');
@@ -23,13 +26,12 @@ const BenchMemberList: React.FC<Props> = ({ items, checkedItems, setCheckedItems
 
   // チェックボックスの状態を更新する関数
   const toggleCheckedItem = (itemId: string) => {
-    const item = items.find(i => i.id === itemId);
-    if (item) {
-      const displayName = getDisplayName(item.name);
-      
-      // GA4イベントを送信（必要に応じて）
-      // trackItemChecked('ベンチメンバー', displayName);
-    }
+    // GA4イベントを送信（必要に応じて）
+    // const item = items.find(i => i.id === itemId);
+    // if (item) {
+    //   const displayName = getDisplayName(item.name);
+    //   trackItemChecked('ベンチメンバー', displayName);
+    // }
     
     setCheckedItems((prev) => {
       const newSet = new Set(prev);
@@ -108,6 +110,33 @@ const BenchMemberList: React.FC<Props> = ({ items, checkedItems, setCheckedItems
                   🏆 必ず買うもの
                 </div>
               </div>
+
+              {/* 削除ボタン */}
+              {!isReadOnly && (
+                <div style={{ marginLeft: '10px' }}>
+                  <button
+                    onClick={() => {
+                      const displayName = getDisplayName(item.name);
+                      
+                      // GA4イベントを送信
+                      trackItemDeleted('ベンチメンバー', displayName);
+                      
+                      onDeleteItem(item.id);
+                    }}
+                    style={{
+                      padding: '4px 8px',
+                      fontSize: '11px',
+                      backgroundColor: '#ff6b6b',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '3px',
+                      cursor: 'pointer'
+                    }}
+                  >
+                    削除
+                  </button>
+                </div>
+              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- ベンチメンバーリストに削除ボタンを実装
- 他のリスト（RegularItemsList）と同じスタイルで統一
- GA4トラッキングを統合してユーザー行動を分析可能に
- 共有ビューでは削除ボタンを非表示にして安全性を確保

## Changes
- `BenchMemberList.tsx`: 削除ボタンUI追加、GA4統合、props拡張
- `App.tsx`: BenchMemberListに必要なpropsを追加、共有ビューでの適切な制御

## Test plan
- [x] TypeScriptコンパイル成功
- [x] Docker環境での動作確認 (localhost:3000)
- [x] ビルド成功確認
- [x] 削除ボタンのスタイルが他のリストと一致することを確認
- [x] 共有ビューで削除ボタンが非表示になることを確認

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)